### PR TITLE
Scope data access in admin panel

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -1,22 +1,25 @@
 {
   "rules": {
-    // Admins can read and write everything
-    ".read": "auth !== null && root.child('admins/' + auth.uid).exists()",
-    ".write": "auth !== null && root.child('admins/' + auth.uid).exists()",
-
     "admins": {
+      // Admins only
+      ".read": "auth !== null && root.child('admins/' + auth.uid).exists()",
+      ".write": "auth !== null && root.child('admins/' + auth.uid).exists()"
     },
 
     "constants": {
-      ".read": true
+      ".read": true,
+      ".write": "auth !== null && root.child('admins/' + auth.uid).exists()"
     },
 
     "studies": {
+      // Admins only
+      ".read": "auth !== null && root.child('admins/' + auth.uid).exists()",
+      ".write": "auth !== null && root.child('admins/' + auth.uid).exists()"
     },
 
     // This data maps UIDs from Firebase auth to user IDs in Qualtrics. This is
-    // used to make sure each user only gets access to the data they need and no
-    // more.
+    // used to make sure each user only gets access to the data they need and
+    // no more.
     //
     // Use the Qualtrics ID in rules with:
     // auth !== null && root.child('user_auth/' + auth.uid).val() === somestuff
@@ -29,6 +32,10 @@
     },
 
     "$study": {
+      // Only admins that have access should be able to read study's data
+      ".read": "auth !== null &&
+        root.hasChild('admins/' + auth.uid + '/' + $study)",
+
       "$roomType": {
         // The user needs to be able to read other user states and move people
         // into rooms.

--- a/src/js/admin/actions/AdminActions.js
+++ b/src/js/admin/actions/AdminActions.js
@@ -1,7 +1,8 @@
 import alt from '../alt';
 import Firebase from 'firebase';
 
-import { ROOT_URL, STUDIES_URL } from '../../constants';
+import {
+  ROOT_URL, STUDIES_URL, permissionDeniedMessage } from '../../constants';
 
 const ROOT_FB = new Firebase(ROOT_URL);
 const STUDIES_FB = new Firebase(STUDIES_URL);
@@ -12,20 +13,17 @@ class AdminActions {
       'setSelectedStudy');
   }
 
-  // No unlisten method cause we shouldn't have to unlisten on this page
   // This only allows admins to auth through
   listenForAuth() {
     ROOT_FB.onAuth((auth) => {
-      ROOT_FB.child('admins').once('value',
-        () => this.dispatch(auth),
-        (err) => this.actions.setAuthError(`${err.toString()} | Send Sam
-          your UID: ${auth.uid} if you believe this is an error.`),
-      );
+      ROOT_FB.child('admins').once('value')
+        .then(() => this.dispatch(auth))
+        .catch((err) => this.actions.setAuthError(err, auth));
     });
   }
 
-  setAuthError(err) {
-    this.dispatch(err.toString());
+  setAuthError(err, auth) {
+    this.dispatch(permissionDeniedMessage(err, auth));
   }
 
   logout() {

--- a/src/js/admin/components/ConfigSetter.jsx
+++ b/src/js/admin/components/ConfigSetter.jsx
@@ -158,7 +158,6 @@ const ConfigSetter = React.createClass({
   },
 
   _handleMessageTypeChange(e) {
-    console.log(e.target.value);
     const messageObject = this.state.messageObject;
     messageObject.type = e.target.value;
     this.setState({ messageObject: messageObject });
@@ -184,7 +183,6 @@ const ConfigSetter = React.createClass({
   },
 
   _renderMessageTable() {
-    console.log(this.state.config.messages);
     const tableStyle = {
       margin: '0 auto',
     };

--- a/src/js/admin/components/LoginButton.jsx
+++ b/src/js/admin/components/LoginButton.jsx
@@ -40,7 +40,7 @@ const LoginButton = React.createClass({
         </div>
         :
         <div className="button" onClick={this._loginPopup}>
-          Log in through Google.
+          Log in through Google
         </div>
       }
 

--- a/src/js/admin/components/LoginButton.jsx
+++ b/src/js/admin/components/LoginButton.jsx
@@ -20,8 +20,7 @@ const LoginButton = React.createClass({
   _loginPopup() {
     this.props.fb.authWithOAuthPopup('google', (err, auth) => {
       if (err) {
-        AdminActions.setAuthError(`${err.toString()} | Send Sam your UID:
-          ${auth.uid} if you believe this is an error.`);
+        AdminActions.setAuthError(err, auth);
       } else {
         // We're listening to auth so the store will get the new value
       }

--- a/src/js/admin/components/StudyList.jsx
+++ b/src/js/admin/components/StudyList.jsx
@@ -36,7 +36,6 @@ const StudyList = React.createClass({
   },
 
   _handleSelectStudy(study) {
-    console.log(study);
     AdminActions.setSelectedStudy(study);
   },
 

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -18,6 +18,11 @@ const MESSAGE_TYPES = {
   confederate: 'Confederate',
 };
 
+function permissionDeniedMessage(err, auth) {
+  return `${err.toString()} | Send Sam your UID:
+    ${auth.uid} if you believe this is an error.`;
+}
+
 export default {
   ROOT_URL,
   STUDIES_URL,
@@ -25,6 +30,7 @@ export default {
   USER_AUTH_URL,
   DEFAULT_ROOM_VALUES,
   MESSAGE_TYPES,
+  permissionDeniedMessage,
 };
 
 

--- a/src/js/json_to_csv/actions.js
+++ b/src/js/json_to_csv/actions.js
@@ -1,7 +1,7 @@
 import Firebase from 'firebase';
 import { createAction } from 'redux-actions';
 
-import { ROOT_URL, STUDIES_URL } from '../constants';
+import { ROOT_URL, STUDIES_URL, permissionDeniedMessage } from '../constants';
 
 const ROOT_FB = new Firebase(ROOT_URL);
 const STUDIES_FB = new Firebase(STUDIES_URL);
@@ -11,6 +11,9 @@ export const setStudy = createAction('SET_STUDY');
 export const setDisplayOption = createAction('SET_DISPLAY_OPTION');
 export const startDataFetch = createAction('START_DATA_FETCH');
 export const setData = createAction('SET_DATA');
+
+export const setError = createAction('SET_ERROR',
+  (err, auth) => permissionDeniedMessage(err, auth));
 
 export function fetchStudyList() {
   return (dispatch) => {
@@ -24,7 +27,10 @@ export function setStudyAndStartFetch(study) {
     dispatch(setStudy(study));
     dispatch(startDataFetch(study));
 
+    const auth = ROOT_FB.getAuth();
+
     return ROOT_FB.child(study).once('value')
-      .then(response => dispatch(setData(response.val())));
+      .then(response => dispatch(setData(response.val())))
+      .catch(err => dispatch(setError(err, auth)));
   };
 }

--- a/src/js/json_to_csv/components.js
+++ b/src/js/json_to_csv/components.js
@@ -68,7 +68,8 @@ class JSONToCSV extends React.Component {
   }
 
   render() {
-    const { studyList, displayOption, data, onSelectOption } = this.props;
+    const { studyList, displayOption, error, data,
+      onSelectOption } = this.props;
     let selectedOption;
 
     return (<div>
@@ -85,6 +86,8 @@ class JSONToCSV extends React.Component {
 
       <br />
 
+      {error}
+
       {data && <DataDisplay
         onSelectOption={onSelectOption}
         displayOption={displayOption}
@@ -99,6 +102,7 @@ JSONToCSV.propTypes = {
   studyList: PropTypes.array.isRequired,
   study: PropTypes.string.isRequired,
   displayOption: PropTypes.string.isRequired,
+  error: PropTypes.string,
   data: dataShape,
 
   // Callbacks

--- a/src/js/json_to_csv/reducer.js
+++ b/src/js/json_to_csv/reducer.js
@@ -38,6 +38,7 @@ const defaultState = {
   fetchingStudyList: true,
   displayOption: 'USERS',
   fetchingData: false,
+  error: null,
   data: null,
 };
 
@@ -53,10 +54,24 @@ const jsonCsvApp = handleActions({
   SET_DISPLAY_OPTION: (state, action) =>
     ({ ...state, displayOption: action.payload }),
 
-  START_DATA_FETCH: (state, action) => ({ ...state, fetchingData: true }),
+  START_DATA_FETCH: (state, action) => ({
+    ...state,
+    error: null,
+    fetchingData: true,
+  }),
 
-  SET_DATA: (state, action) =>
-    ({ ...state, fetchingData: false, data: action.payload }),
+  SET_DATA: (state, action) => ({
+    ...state,
+    fetchingData: false,
+    error: null,
+    data: action.payload,
+  }),
+
+  SET_ERROR: (state, action) => ({
+    ...state,
+    error: action.payload,
+    data: null,
+  }),
 
 }, defaultState);
 

--- a/src/js/json_to_csv/utils.js
+++ b/src/js/json_to_csv/utils.js
@@ -1,0 +1,37 @@
+/**
+ * Utils for JsonToCsv
+ */
+import _ from 'underscore';
+import BabyParse from 'babyparse';
+
+// Extracts Room,Room ID,User ID from data
+export function extractUserData(data) {
+  const USER_CSV_FIELDS = ['Room', 'Room ID', 'User ID'];
+  const csvData = [];
+
+  _.mapObject(data, (roomTypeData, roomType) => {
+    _.mapObject(roomTypeData.rooms, (roomData, room) => {
+      _.mapObject(roomData.users, (userVal, user) => {
+        csvData.push([roomType, room, user]);
+      });
+    });
+  });
+
+  return BabyParse.unparse({ fields: USER_CSV_FIELDS, data: csvData });
+}
+
+// Extracts Room ID,User ID,Message from data
+export function extractMessageData(data) {
+  const MESSAGES_CSV_FIELDS = ['Room ID', 'User ID', 'Message'];
+  const csvData = [];
+
+  _.mapObject(data, (roomTypeData, roomType) => {
+    _.mapObject(roomTypeData.rooms, (roomData, room) => {
+      _.each(roomData.messages, ({ message, userId }) => {
+        csvData.push([room, userId, message]);
+      });
+    });
+  });
+
+  return BabyParse.unparse({ fields: MESSAGES_CSV_FIELDS, data: csvData });
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,6 @@ var webpack = require("webpack");
 module.exports = {
     entry: {
         chat: ["./src/js/chat.js"],
-        json_to_csv: ["./src/js/json_to_csv.js"],
         admin: ["./src/js/admin.js"],
     },
     resolve: {


### PR DESCRIPTION
This PR changes the ability of admins to access data. Before, all admins can
access any study's data.

Now, admins can only access the data of studies they have access to. This is
implemented in Firebase by changing the `admin` key to look like:

```
{
  admins: {
    <uid1>: {
      ProjectA: true,
      ProjectB: true,
    },
    <uid2>: {
      ProjectC: true,
    },
    ...
  }
}
```

Before, each `<uid>` simply mapped to a `true` value. To give an admin access
to a study's data, we have to manually go into the Firebase and add the project
to the admin's key. This is cumbersome, but secure — client-side passwords are
not secure at all.
