### PR TITLE
Use https for generated URLs

### DIFF
--- a/src/js/admin/components/RoomGenerator.jsx
+++ b/src/js/admin/components/RoomGenerator.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import _ from 'underscore';
 
+import { BASE_CHAT_ROOM_URL } from '../../constants';
+
 const USER_ID_FIELD = 'user_id=${e://Field/CHATROOM%20ID}';
 
 /**
@@ -28,8 +30,10 @@ const RoomGenerator = React.createClass({
       return '';
     }
 
-    return `https://samlau95.github.io/pg-chat-room?study=` +
-      `${this.props.selectedStudy}&room=${this.state.room}&${USER_ID_FIELD}`;
+    return BASE_CHAT_ROOM_URL +
+      `?study=${this.props.selectedStudy}` +
+      `&room=${this.state.room}` +
+      `&${USER_ID_FIELD}`;
   },
 
   render() {

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -4,6 +4,8 @@ const STUDIES_URL = `${ROOT_URL}/studies`;
 const CONSTANTS_URL = `${ROOT_URL}/constants`;
 const USER_AUTH_URL = `${ROOT_URL}/user_auth`;
 
+const BASE_CHAT_ROOM_URL = 'https://www.samlau.me/pg-chat-room';
+
 const DEFAULT_ROOM_VALUES = {
   usersPerRoom: '3',
   maxWaitingTime: 300000,
@@ -23,8 +25,7 @@ export default {
   STUDIES_URL,
   CONSTANTS_URL,
   USER_AUTH_URL,
+  BASE_CHAT_ROOM_URL,
   DEFAULT_ROOM_VALUES,
   MESSAGE_TYPES,
 };
-
-


### PR DESCRIPTION
This fixes a bug where the browser fails to load the chat room if Qualtrics is
using https because the URLs are using http.

I'm actually running an nginx proxy in front of my domain to make this work
lol.
