### PR TITLE
Add error message when admin not allowed to look at data

### DIFF
--- a/src/js/json_to_csv/actions.js
+++ b/src/js/json_to_csv/actions.js
@@ -11,6 +11,7 @@ export const setStudy = createAction('SET_STUDY');
 export const setDisplayOption = createAction('SET_DISPLAY_OPTION');
 export const startDataFetch = createAction('START_DATA_FETCH');
 export const setData = createAction('SET_DATA');
+export const failedDataFetch = createAction('FAILED_DATA_FETCH');
 
 export function fetchStudyList() {
   return (dispatch) => {
@@ -25,6 +26,7 @@ export function setStudyAndStartFetch(study) {
     dispatch(startDataFetch(study));
 
     return ROOT_FB.child(study).once('value')
-      .then(response => dispatch(setData(response.val())));
+      .then(response => dispatch(setData(response.val())))
+      .catch(err => dispatch(failedDataFetch(err)));
   };
 }

--- a/src/js/json_to_csv/components.js
+++ b/src/js/json_to_csv/components.js
@@ -81,8 +81,14 @@ class JSONToCSV extends React.Component {
   }
 
   render() {
-    const { studyList,
-            displayOption, data, dispatch } = this.props;
+    const {
+      studyList,
+      displayOption,
+      data,
+      dispatch,
+      error,
+    } = this.props;
+
     let studySelect;
 
     return (<div>
@@ -101,6 +107,8 @@ class JSONToCSV extends React.Component {
       </form>
 
       <br />
+      {error}
+
       {data && <form>
         <input type="radio" value="USERS"
           id="users"
@@ -125,6 +133,7 @@ JSONToCSV.propTypes = {
   displayOption: PropTypes.string.isRequired,
   data: dataShape,
   dispatch: PropTypes.func.isRequired,
+  error: PropTypes.object,
 };
 
 const mapStateToProps = (state) => state;

--- a/src/js/json_to_csv/reducer.js
+++ b/src/js/json_to_csv/reducer.js
@@ -39,6 +39,7 @@ const defaultState = {
   displayOption: 'USERS',
   fetchingData: false,
   data: null,
+  error: null,
 };
 
 const jsonCsvApp = handleActions({
@@ -57,6 +58,13 @@ const jsonCsvApp = handleActions({
 
   SET_DATA: (state, action) =>
     ({ ...state, fetchingData: false, data: action.payload }),
+
+  FAILED_DATA_FETCH: (state, action) => ({
+    ...state,
+    fetchingData: false,
+    data: null,
+    error: action.payload.toString(),
+  }),
 
 }, defaultState);
 


### PR DESCRIPTION
Before we would just silently throw a JS error. Now there's a slightly more
helpful message that appears when an admin doesn't have permission to access
the data.
