### PR TITLE
Apparently github pages need a trailing slash

### DIFF
--- a/src/js/admin/components/RoomGenerator.jsx
+++ b/src/js/admin/components/RoomGenerator.jsx
@@ -30,7 +30,7 @@ const RoomGenerator = React.createClass({
       return '';
     }
 
-    return BASE_CHAT_ROOM_URL +
+    return BASE_CHAT_ROOM_URL + '/' +
       `?study=${this.props.selectedStudy}` +
       `&room=${this.state.room}` +
       `&${USER_ID_FIELD}`;


### PR DESCRIPTION
@charlesx2013 

This fixes the chatroom URL issue. His other issues are things that you can fix on the Firebase dashboard.
